### PR TITLE
Include the LICENSE in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
To show the redistribution rights, useful for example in the case where we repackage this as a conda recipe.