### PR TITLE
Protect code changes while running

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 A simple extension for Jupyter Notebook and Jupyter Lab to beautify Python code automatically using **Black**.
 
-Please note that since the **Black** package only supports Python 3.6+, so **YAPF** package will be used for the lower versions. And please **DO NOT EDIT** your code while running cell, otherwise your new code will be replaced by the formatted code.
+Please note that since the **Black** package only supports Python 3.6+, so **YAPF** package will
+be used for the lower versions. If you edit the code while running the cell, the formatting is
+not submitted to the Jupyter notebook and instead silently suppressed, so you have to stick with
+the edited, but unformatted code.
 
 ## Installation
 

--- a/lab_black.py
+++ b/lab_black.py
@@ -201,7 +201,7 @@ class BlackFormatter(object):
             )
             display(Javascript(js_code))
 
-    def format_cell(self, result):
+    def format_cell(self, *args, **kwargs):
         try:
             cell_id = len(self.shell.user_ns["In"]) - 1
             if cell_id > 0:

--- a/lab_black.py
+++ b/lab_black.py
@@ -174,38 +174,46 @@ class BlackFormatter(object):
         self.shell = ip
         self.is_lab = is_lab
 
-    def __set_cell(self, cell, cell_id=None):
+    def __set_cell(self, unformatted_cell, cell, cell_id=None):
         if self.is_lab:
             self.shell.set_next_input(cell, replace=True)
         else:
             js_code = """
             setTimeout(function() {
                 var nbb_cell_id = %d;
+                var nbb_unformatted_code = %s;
                 var nbb_formatted_code = %s;
                 var nbb_cells = Jupyter.notebook.get_cells();
                 for (var i = 0; i < nbb_cells.length; ++i) {
                     if (nbb_cells[i].input_prompt_number == nbb_cell_id) {
-                        nbb_cells[i].set_text(nbb_formatted_code);
+                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {
+                             nbb_cells[i].set_text(nbb_formatted_code);
+                        }
                         break;
                     }
                 }
             }, 500);
             """
-            display(Javascript(js_code % (cell_id, json.dumps(cell))))
+            js_code = js_code % (
+                cell_id,
+                json.dumps(unformatted_cell),
+                json.dumps(cell),
+            )
+            display(Javascript(js_code))
 
-    def format_cell(self, *args, **kwargs):
+    def format_cell(self, result):
         try:
             cell_id = len(self.shell.user_ns["In"]) - 1
             if cell_id > 0:
-                cell = self.shell.user_ns["_i" + str(cell_id)]
+                unformatted_cell = self.shell.user_ns["_i" + str(cell_id)]
 
-                if re.search(r"^\s*%load(py)? ", cell, flags=re.M):
+                if re.search(r"^\s*%load(py)? ", unformatted_cell, flags=re.M):
                     return
 
                 hidden_variables = []
 
                 # Transform magic commands into special variables
-                cell = _transform_magic_commands(cell, hidden_variables)
+                cell = _transform_magic_commands(unformatted_cell, hidden_variables)
 
                 formatted_code = _format_code(cell)
 
@@ -214,7 +222,7 @@ class BlackFormatter(object):
                     formatted_code, hidden_variables
                 )
 
-                self.__set_cell(formatted_code.strip(), cell_id)
+                self.__set_cell(unformatted_cell, formatted_code.strip(), cell_id)
         except (ValueError, TypeError, AssertionError) as err:
             logging.exception(err)
 


### PR DESCRIPTION
Even if the documentation says, don't change your code while running,
it's not good if the user does it and then code gets overwritten.
It's especially painfull when you restructure code as the whole counting
gets confused and in the end code gets changed in other cells, too :-(

So, I add here some logic that checks that the unformatted code is the
same as found **before** running the cell. If not, for w/e reason, don't
set the code cell to the black formatted code.

It would be better, if the user would get any notification in case (like
a warning logging event or some tooltip or some additional output), but
my knowledge of the Javascript Python interaction is not good enough to
do it right now. It might be best to do the formatting on frontend side,
but well, so let's integrate black into Javascript frontend another time
:-o

Nonetheless, this PR should protect the integrity of the
jupyter notebook what's more important and still allow an interactive
workflow :-)