### PR TITLE
Ignore trailing whitespace in cell comparison

### DIFF
--- a/lab_black.py
+++ b/lab_black.py
@@ -186,7 +186,7 @@ class BlackFormatter(object):
                 var nbb_cells = Jupyter.notebook.get_cells();
                 for (var i = 0; i < nbb_cells.length; ++i) {
                     if (nbb_cells[i].input_prompt_number == nbb_cell_id) {
-                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {
+                        if (nbb_cells[i].get_text().trim() == nbb_unformatted_code) {
                              nbb_cells[i].set_text(nbb_formatted_code);
                         }
                         break;


### PR DESCRIPTION
**Issue**
If you have trailing whitespace in a Jupyter notebook cell, nb-black won't format it.  For example (note the newline):

<pre>
a=1

 </pre>

I have tested it with newlines and spaces.

**Fix**
It happens because `nbb_unformatted_code` (which comes from `self.shell.user_ns["_i" + str(cell_id)]`) is stripped of whitespace (not sure why but it is out of our control).  Therefore, we should strip whitespace from `nbb_cells[i].get_text()` before we compare it to `nbb_unformatted_code`.