### PR TITLE
Issue 17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     version="1.0.7",
     description="A simple extension for Jupyter Notebook and Jupyter Lab to beautify Python code automatically using Black.",
     long_description=readme(file_name="README.md"),
+    long_description_content_type="text/markdown",
     keywords="black-formatter black-beautifier black jupyterlab-extension jupyter-notebook-extension",
     url="https://github.com/dnanhkhoa/nb_black",
     author="Khoa Duong",

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
     py_modules=["nb_black", "lab_black"],
     zip_safe=False,
     install_requires=[
-        "yapf >= '0.28'; python_version < '3.6'",
-        "black >= '19.3'; python_version >= '3.6'",
+        "yapf >= 0.28; python_version < '3.6'",
+        "black >= 19.3; python_version >= '3.6'",
         "ipython",
     ],
     classifiers=[


### PR DESCRIPTION
As mentioned in #17, the quotes in the `install_requires` list break some bits of anaconda.  In particular, running `conda env export` breaks.  Note that the python versions (3.6) still have to be quoted.