### PR TITLE
Run our example notebook and verify the output

### DIFF
--- a/test/example.ipynb
+++ b/test/example.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each code cell should be followed by a raw cell.  The raw cell should show what the executed and formatted code cell should look like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "formatting\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function writeToCell () {\n",
+       "\n",
+       "                var nbb_cell_id = 1;\n",
+       "                var nbb_unformatted_code = \"%load_ext nb_black\";\n",
+       "                var nbb_formatted_code = \"%load_ext nb_black\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number === nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() === nbb_unformatted_code) {\n",
+       "                            nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%load_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "%load_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "formatting\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function writeToCell () {\n",
+       "\n",
+       "                var nbb_cell_id = 2;\n",
+       "                var nbb_unformatted_code = \"%reload_ext nb_black\";\n",
+       "                var nbb_formatted_code = \"%reload_ext nb_black\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number === nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() === nbb_unformatted_code) {\n",
+       "                            nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%reload_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "%reload_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "formatting\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function writeToCell () {\n",
+       "\n",
+       "                var nbb_cell_id = 3;\n",
+       "                var nbb_unformatted_code = \"a = 1\";\n",
+       "                var nbb_formatted_code = \"a = 1\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number === nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() === nbb_unformatted_code) {\n",
+       "                            nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "a = 1"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "a = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%unload_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "%unload_ext nb_black"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/test_notebook.py
+++ b/test/test_notebook.py
@@ -1,0 +1,79 @@
+import unittest
+import time
+import subprocess
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+
+
+class NBBlackTest(unittest.TestCase):
+    """Run our example notebook and check that the cells are
+    formatted as expected.  Requires jupyter notebook to be
+    running already."""
+
+    def setUp(self):
+        # Get the access token
+        completed_process = subprocess.run(
+            "jupyter notebook list".split(), capture_output=True
+        )
+        output_lines = completed_process.stdout.decode("utf-8").split("\n")
+
+        # There should be one intro line, one server line and an empty line
+        if len(output_lines) != 3:
+            raise RuntimeError("Too many or too few running notebook servers.")
+
+        server = output_lines[1]
+        token_starts = server.find("?token=")
+        token_ends = server.find(" ")
+        self.token = server[token_starts:token_ends]
+
+        # Start the web browser
+        options = webdriver.firefox.options.Options()
+        # options.headless = True
+        self.driver = webdriver.Firefox(options=options)
+
+    def tearDown(self):
+        self.driver.quit()
+
+    def test_example_notebook(self):
+        # ToDo Get this token somehow (run jupyter as a sub-process?)
+        self.driver.get(
+            "http://127.0.0.1:8888/notebooks/test/example.ipynb" + self.token
+        )
+
+        # ToDo wait for page to be loaded
+        time.sleep(1)
+
+        # Restart kernel and run workbook (relies on Ctrl-Shift-a shortcut)
+        body = self.driver.find_element_by_tag_name("body")
+        body.send_keys(Keys.ESCAPE)
+        body.send_keys(Keys.LEFT_CONTROL, Keys.LEFT_SHIFT, "a")
+
+        # ToDo wait for last cell to be run
+        time.sleep(1)
+
+        code_cells = self.driver.find_elements_by_class_name("code_cell")
+        text_cells = self.driver.find_elements_by_class_name("text_cell")
+        text_cells = text_cells[1:]  # ignore the first cell, which is a markdown intro
+        assert len(code_cells) > 1
+        assert len(code_cells) == len(text_cells)
+
+        # The example notebook has alternating code and text cells
+        for i in range(len(code_cells)):
+            code = code_cells[i].text
+
+            # We don't want the "In[1]:\n"
+            code_starts = code.find("\n") + 1
+            code = code[code_starts:]
+
+            # We don't want our JavaScript object at the end
+            javascript = code.find("\n<IPython.core.display.Javascript object>")
+            if javascript > -1:
+                code = code[:javascript]
+
+            text = text_cells[i].text
+
+            self.assertEqual(text, code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is entirely optional but would be nice to put on a CI server or something...

One option for testing nb-black is to have an .ipynb notebook and to run it using Selenium.  After each code cell is a raw cell which shows what the code cell should look like after formatting.  It would have picked up on the trailing whitespace issue and any issues with loading/unloading/reloading. 

I run all the cells with a keyboard shortcut at the moment but there might be a better way.