### PR TITLE
Remove yapf requirement to support python > 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     py_modules=["nb_black", "lab_black"],
     zip_safe=False,
     install_requires=[
-        "yapf >= 0.28; python_version < '3.6'",
         "black >= 19.3; python_version >= '3.6'",
         "ipython",
     ],


### PR DESCRIPTION
This PR fixes https://github.com/dnanhkhoa/nb_black/issues/40. Based on @IsaGrue's fork https://github.com/IsaGrue/nb_black